### PR TITLE
Example: generic tensor network

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 *.jl.*.cov
 *.jl.cov
 *.jl.mem
-/Manifest.toml
+Manifest.toml
 lib
 .vscode
 Artifact

--- a/examples/combinatorial-optimization/Project.toml
+++ b/examples/combinatorial-optimization/Project.toml
@@ -1,0 +1,13 @@
+[deps]
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+CuTropicalGEMM = "c2b282c3-c9c2-431d-80f7-a1a0561ebe55"
+GenericTensorNetworks = "3521c873-ad32-4bb4-b63d-f4f178f42b49"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+TropicalNumbers = "b3a74e9c-7526-4576-a4eb-79c0d4c32334"
+
+[compat]
+CUDA = "5"
+CuTropicalGEMM = "0.1"
+GenericTensorNetworks = "1"
+TropicalNumbers = "0.6"
+julia = "1.9"

--- a/examples/combinatorial-optimization/README.md
+++ b/examples/combinatorial-optimization/README.md
@@ -1,0 +1,8 @@
+# Solving combinatorial optimization problem with generic tensor networks
+
+## Problem description
+
+We consider solving the maximum independent set problem. Please check [the manual page](https://queracomputing.github.io/GenericTensorNetworks.jl/dev/generated/IndependentSet/) of package [GenericTensorNetworks.jl](https://github.com/QuEraComputing/GenericTensorNetworks.jl) [1] for a detailed description of the problem.
+
+## References
+1. Liu, J.-G., Gao, X., Cain, M., Lukin, M. D. & Wang, S.-T. Computing solution space properties of combinatorial optimization problems via generic tensor networks. Preprint at https://doi.org/10.48550/arXiv.2205.03718 (2022).

--- a/examples/combinatorial-optimization/main.jl
+++ b/examples/combinatorial-optimization/main.jl
@@ -1,0 +1,22 @@
+using GenericTensorNetworks, CUDA, TropicalNumbers, GenericTensorNetworks.Graphs
+using CuTropicalGEMM
+using Random; Random.seed!(2)
+
+# Create a random 3-regular graph
+g = GenericTensorNetworks.random_diagonal_coupled_graph(38, 38, 0.8)
+
+# Create a tensor network representation for the independent set problem on this graph
+# Let us specify the tensor network contraction order optimizer to be TreeSA, which is a local search algorithm
+tn = IndependentSet(g; optimizer=TreeSA(ntrials=1, niters=5))
+
+# Let us check its contraction complexity
+contraction_complexity(tn)
+
+# Let us find the maximum independent set using the tensor network contraction.
+# It will use the CuTropicalGEMM library to perform the contraction.
+# Please use Float32 type for the best performance.
+@time Array(solve(tn, SizeMax(); usecuda=true, T=Float32))
+# output: 1.1s
+
+# If you want to use the automatic differentiation based approach to find the optimal solution.
+@time solve(tn, SingleConfigMax(; bounded=true); usecuda=true, T=Float32)


### PR DESCRIPTION
# To run the example
```bash
cd examples/combinatorial-optimization
julia --project -e "using Pkg; Pkg.instantiate()"
julia --project main.jl
```
# Performance
Device: NVIDIA RTX A4500, CUDA 12.0

## Before CuTropicalGEMM
```julia
julia> @time Array(solve(tn, SizeMax(); usecuda=true, T=Float32));
 10.772101 seconds (1.79 M allocations: 83.646 MiB, 0.95% gc time)

@time solve(tn, SingleConfigMax(; bounded=true); usecuda=true, T=Float32);
 42.961929 seconds (11.23 M allocations: 425.264 MiB, 0.29% gc time, 0.06% compilation time)
```

## After CuTropicalGEMM
```julia
julia> @time Array(solve(tn, SizeMax(); usecuda=true, T=Float32));
  1.109122 seconds (1.29 M allocations: 61.970 MiB)

julia> @time solve(tn, SingleConfigMax(; bounded=true); usecuda=true, T=Float32);
 20.308956 seconds (9.96 M allocations: 366.654 MiB, 0.48% gc time, 0.01% compilation time)
```

## Profile
```julia
julia> CUDA.@profile Array(solve(tn, SizeMax(); usecuda=true, T=Float32))
Profiler ran for 1.7 s, capturing 157501 events.

Host-side activity: calling CUDA APIs took 732.81 ms (43.10% of the trace)
┌──────────┬───────────┬───────┬───────────┬───────────┬───────────┬─────────────────────────┐
│ Time (%) │      Time │ Calls │  Avg time │  Min time │  Max time │ Name                    │
├──────────┼───────────┼───────┼───────────┼───────────┼───────────┼─────────────────────────┤
│   32.07% │ 545.26 ms │  8289 │  65.78 µs │    3.1 µs │ 507.52 ms │ cudaLaunchKernel        │
│   22.21% │  377.7 ms │  4694 │  80.47 µs │   2.86 µs │   60.8 ms │ cuStreamSynchronize     │
│    4.17% │  70.98 ms │ 14646 │   4.85 µs │   2.15 µs │ 416.76 µs │ cuMemAllocFromPoolAsync │
│    2.81% │  47.79 ms │  4692 │  10.19 µs │   3.34 µs │  11.46 ms │ cuMemcpyHtoDAsync       │
│    2.26% │  38.41 ms │  6967 │   5.51 µs │   3.81 µs │  45.06 µs │ cuLaunchKernel          │
│    0.01% │ 211.95 µs │     1 │ 211.95 µs │ 211.95 µs │ 211.95 µs │ cuMemcpyDtoHAsync       │
└──────────┴───────────┴───────┴───────────┴───────────┴───────────┴─────────────────────────┘

Device-side activity: GPU was busy for 712.51 ms (41.90% of the trace)
┌──────────┬───────────┬───────┬───────────┬───────────┬───────────┬───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ Time (%) │      Time │ Calls │  Avg time │  Min time │  Max time │ Name                                                                                                                                                 ⋯
├──────────┼───────────┼───────┼───────────┼───────────┼───────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│   38.98% │ 662.74 ms │  8282 │  80.02 µs │   3.58 µs │  534.3 ms │ _Z16FLOAT_maxplus_NNILi64ELi32ELi64ELi4ELi4EEvPfS0_S0_ffiiiii                                                                                        ⋯
│    0.74% │   12.6 ms │    11 │   1.15 ms │   1.43 µs │  12.45 ms │ _Z18permutedims_kernel15CuKernelContext13CuDeviceArrayI8TropicalI7Float32ELi1ELi1EES0_IS1_IS2_ELi1ELi1EE5TupleI6UInt32S4_S4_S4_S4_S4_S4_S4_S4_ES3_IS ⋯
│    0.73% │  12.47 ms │    33 │ 377.79 µs │   1.19 µs │  12.35 ms │ _Z18permutedims_kernel15CuKernelContext13CuDeviceArrayI8TropicalI7Float32ELi1ELi1EES0_IS1_IS2_ELi1ELi1EE5TupleI6UInt32S4_S4_S4_S4_S4_S4_S4_ES3_IS4_S ⋯
│    0.48% │   8.24 ms │     4 │   2.06 ms │  10.49 µs │   4.16 ms │ _Z18permutedims_kernel15CuKernelContext13CuDeviceArrayI8TropicalI7Float32ELi1ELi1EES0_IS1_IS2_ELi1ELi1EE5TupleI6UInt32S4_S4_S4_S4_S4_S4_S4_S4_S4_S4_ ⋯
│    0.26% │   4.47 ms │  3329 │   1.34 µs │ 953.67 ns │   4.05 µs │ _Z18permutedims_kernel15CuKernelContext13CuDeviceArrayI8TropicalI7Float32ELi1ELi1EES0_IS1_IS2_ELi1ELi1EE5TupleI6UInt32S4_ES3_IS4_S4_E                ⋯
│    0.20% │    3.4 ms │  4692 │ 725.62 ns │ 238.42 ns │   2.38 µs │ [copy pageable to device memory]                                                                                                             
...

julia> CUDA.@profile solve(tn, SingleConfigMax(; bounded=true); usecuda=true, T=Float32)
Profiler ran for 28.53 s, capturing 1077654 events.

Host-side activity: calling CUDA APIs took 9.62 s (33.72% of the trace)
┌──────────┬───────────┬───────┬───────────┬──────────┬───────────┬─────────────────────────┐
│ Time (%) │      Time │ Calls │  Avg time │ Min time │  Max time │ Name                    │
├──────────┼───────────┼───────┼───────────┼──────────┼───────────┼─────────────────────────┤
│   59.20% │   16.89 s │ 70375 │ 240.04 µs │  2.15 µs │    2.99 s │ cuStreamSynchronize     │
│    3.16% │ 900.96 ms │ 63114 │  14.28 µs │  3.81 µs │   7.76 ms │ cuLaunchKernel          │
│    2.87% │  818.6 ms │ 25043 │  32.69 µs │  3.34 µs │  548.1 ms │ cudaLaunchKernel        │
│    2.70% │ 770.51 ms │ 23459 │  32.84 µs │ 14.07 µs │ 534.53 µs │ cuMemcpyDtoHAsync       │
│    1.74% │ 495.97 ms │ 53489 │   9.27 µs │  2.15 µs │   1.02 ms │ cuMemAllocFromPoolAsync │
│    1.06% │ 302.92 ms │ 23457 │  12.91 µs │  3.58 µs │   3.81 ms │ cuMemcpyHtoDAsync       │
└──────────┴───────────┴───────┴───────────┴──────────┴───────────┴─────────────────────────┘

Device-side activity: GPU was busy for 7.8 s (27.34% of the trace)
┌──────────┬───────────┬───────┬───────────┬───────────┬───────────┬───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ Time (%) │      Time │ Calls │  Avg time │  Min time │  Max time │ Name                                                                                                                                                 ⋯
├──────────┼───────────┼───────┼───────────┼───────────┼───────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│   22.70% │    6.48 s │ 24932 │ 259.74 µs │    3.1 µs │ 582.84 ms │ _Z16FLOAT_maxplus_NNILi64ELi32ELi64ELi4ELi4EEvPfS0_S0_ffiiiii                                                                                        ⋯
│    1.21% │  345.8 ms │     1 │  345.8 ms │  345.8 ms │  345.8 ms │ _Z16broadcast_kernel15CuKernelContext13CuDeviceArrayI8TropicalI7Float32ELi28ELi1EE11BroadcastedI12CuArrayStyleILi28EE5TupleI5OneToI5Int64ES6_IS7_ES6 ⋯
│    1.01% │ 286.84 ms │     2 │ 143.42 ms │ 140.71 ms │ 146.13 ms │ _Z16broadcast_kernel15CuKernelContext13CuDeviceArrayI8TropicalI7Float32ELi27ELi1EE11BroadcastedI12CuArrayStyleILi27EE5TupleI5OneToI5Int64ES6_IS7_ES6 ⋯
│    0.40% │ 114.32 ms │  9382 │  12.19 µs │   2.38 µs │  31.29 ms │ _Z22partial_mapreduce_grid8identity9reductionI6islessE5TupleI4Bool5Int64E16CartesianIndicesILi1ES2_I5OneToIS4_EEES5_ILi1ES2_IS6_IS4_EEE3ValILinfalse ⋯
│    0.35% │ 100.62 ms │ 23459 │   4.29 µs │ 476.84 ns │ 161.65 µs │ [copy device to pageable memory]                                                                                                                     ⋯
│    0.26% │  73.67 ms │     1 │  73.67 ms │  73.67 ms │  73.67 ms │ _Z18permutedims_kernel15CuKernelContext13CuDeviceArrayI8TropicalI7Float32ELi1ELi1EES0_IS1_IS2_ELi1ELi1EE5TupleI6UInt32S4_S4_S4_S4_S4_S4_S4_S4_S4_S4_ ⋯
│    0.23% │  65.95 ms │     1 │  65.95 ms │  65.95 ms │  65.95 ms │ _Z16broadcast_kernel15CuKernelContext13CuDeviceArrayI8TropicalI7Float32ELi26ELi1EE11BroadcastedI12CuArrayStyleILi26EE5TupleI5OneToI5Int64ES6_IS7_ES6 ⋯
│    0.21% │  60.48 ms │     2 │  30.24 ms │  11.44 µs │  60.47 ms │ _Z18permutedims_kernel15CuKernelContext13CuDeviceArrayI8TropicalI7Float32ELi1ELi1EES0_IS1_IS2_ELi1ELi1EE5TupleI6UInt32S4_S4_S4_S4_S4_S4_S4_S4_S4_S4_ ⋯
│    0.14% │  39.56 ms │  9382 │   4.22 µs │   1.19 µs │   8.41 ms │ _Z16broadcast_kernel15CuKernelContext13CuDeviceArrayI4BoolLi1ELi1EE11BroadcastedI12CuArrayStyleILi1EE5TupleI5OneToI5Int64EE8isapproxS4_I8ExtrudedIS0 ⋯
│    0.14% │  38.68 ms │    39 │  991.7 µs │   1.43 µs │  19.18 ms │ _Z18permutedims_kernel15CuKernelContext13CuDeviceArrayI8TropicalI7Float32ELi1ELi1EES0_IS1_IS2_ELi1ELi1EE5TupleI6UInt32S4_S4_S4_S4_S4_S4_S4_S4_ES3_IS ⋯
│    0.09% │  24.75 ms │     1 │  24.75 ms │  24.75 ms │  24.75 ms │ _Z16broadcast_kernel15CuKernelContext13CuDeviceArrayI8TropicalI7Float32ELi25ELi1EE11BroadcastedI12CuArrayStyleILi25EE5TupleI5OneToI5Int64ES6_IS7_ES6 ⋯
│    0.07% │  20.93 ms │    96 │ 218.02 µs │   1.19 µs │  13.96 ms │ _Z18permutedims_kernel15CuKernelContext13CuDeviceArrayI8TropicalI7Float32ELi1ELi1EES0_IS1_IS2_ELi1ELi1EE5TupleI6UInt32S4_S4_S4_S4_S4_S4_S4_ES3_IS4_S ⋯
│    0.07% │  20.69 ms │    10 │   2.07 ms │  10.49 µs │   6.73 ms │ _Z18permutedims_kernel15CuKernelContext13CuDeviceArrayI8TropicalI7Float32ELi1ELi1EES0_IS1_IS2_ELi1ELi1EE5TupleI6UInt32S4_S4_S4_S4_S4_S4_S4_S4_S4_S4_ ⋯
...
```